### PR TITLE
Remove JIRA from the Ticket header of the Pull Request Template.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,9 +11,9 @@ Please include a summary of the change as well as the issue that is fixed.
 Please describe your code changes in detail for reviewers. Explain the technical solution you have provided and how it addresses the issue at hand.
 -->
 
-### JIRA Ticket
+### Ticket
 
-<!-- Fill in the Jira ticket with the details of your feature -->
+<!-- Fill in the ticket information with the details of your feature -->
 [XX-1234](https://customink.atlassian.net/browse/XX-1234)
 
 ### Screenshots


### PR DESCRIPTION
### Description

Many of us are using alternatives to Jira for our tickets, including Basecamp and Trello.  This removes `JIRA` from the header and has it ask for a more generic `Ticket`

### Changes

* ~JIRA~ Ticket

### JIRA Ticket

Nope.
