### PR TITLE
Add an optional tasks section to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,8 +34,13 @@ Please include any notes that might be helpful for a reviewer to keep in mind wh
 Common, optional tasks are included here in case you forgot something important.
 -->
 
-- [ ] Include 🎩  Instructions
+- [ ] Include 🎩 Instructions
 - [ ] Update the readme (README.md)
 - [ ] Update the API or architecture docs (e.g. docs/api.md)
+
+##### Library-Specific
 - [ ] Increment the changelog (CHANGELOG.md)
 - [ ] Increment the version number (lib/version.rb)
+- [ ] [Release & Tag][release] the version above in Github
+
+[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,15 @@ Please include any screenshots that communicate the visual story of the change t
 <!--
 Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
 -->
+
+### Optional Tasks
+
+<!--
+Common, optional tasks are included here in case you forgot something important.
+-->
+
+- [ ] Include 🎩  Instructions
+- [ ] Update the readme (README.md)
+- [ ] Update the API or architecture docs (e.g. docs/api.md)
+- [ ] Increment the changelog (CHANGELOG.md)
+- [ ] Increment the version number (lib/version.rb)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,5 +25,5 @@ Please include any screenshots that communicate the visual story of the change t
 ### Notes
 
 <!--
-Any notes that might be helpful for a reviewer to keep in mind while reading the changes.
+Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
 -->


### PR DESCRIPTION
### Description

Adds an Optional Tasks section to the pull request template.
These are common, but important optional tasks that I sometimes forget to include in my pull requests.

### Changes

* Adds a "Please include" to the notes section, to match convention
* Adds an optional tasks section to the PR template

### Screenshots

![updates](https://user-images.githubusercontent.com/2841/87452829-b0015180-c5cf-11ea-8613-623cb86b8d53.png)




