### PR TITLE
Add usage example for env vars github action

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -57,6 +57,18 @@ Common, optional tasks are included here in case you forgot something important.
 
 [release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository
 
+<!--
+##### Environment Variables
+
+Set custom environment variables for your frontend staging deploy.
+Setup your repo to use this feature by following the instructions located here: https://github.com/customink/frontend-gh-actions
+
+Environment Variables
+```
+TEST_VAR=TEST_VAL
+```
+-->
+
 ##### Performance
 - Are there any new queries in your change set that might require new indexes?
 - Do any new queries require time-boxing to avoid table-scans when the data grows?


### PR DESCRIPTION
### Description

<!--
Describe the relevant motivation and context for this change.
Please include a summary of the change as well as the issue that is fixed.
-->

We would like to add a usage example for frontend applications that would like to use [this github action](https://github.com/customink/frontend-gh-actions) to set environment variables for staging deploys. 

### Changes

<!--
Please describe your code changes in detail for reviewers. Explain the technical solution you have provided and how it addresses the issue at hand.
-->

Added a section to the PR template that is commented out by default.

##### Updated Dependencies
 - None
<!--
Please include any notes that might be helpful for a reviewer to check the dependency changes you might have introduced.
  - gem version update
  - new gem introduced
  - data model update
-->

### Notes

_Recommended reading: [Code Review guide](https://github.com/customink/guides/blob/master/operations/code-review/README.md)_

<!--
Please include any notes that might be helpful for a reviewer to keep in mind while reading the changes.
-->

I'm open to alternatives if anyone feels that this content is not appropriate for a PR template that is used by different application types. In a perfect world, I would extend this template to include frontend-specific content for the repos that would use it. I don't know of a way to extend the template without overwriting it completely, but if there is a way to do that, please let me know. I would like to continue using the default template (and any future updates it contains), if at all possible. 


### What GIF Best Describes This Pull Request?

![](https://i.giphy.com/media/jWNMHoUyjHvecYq7wa/source.gif)

