### PR TITLE
Add risk assessment section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,8 +19,7 @@ Bad example:
 change ingress
 -->
 
-### Risk Assessment
-
+### Risk Assessment _[(learn more)](https://app.getguru.com/card/iMnRRRjT/PR-Risk-Assessment)_
 <!-- Describe the risk of this change and how it will be tested, deployed, and verified. -->
 
 - [ ] Large/complex change?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,16 @@ Bad example:
 change ingress
 -->
 
+### Risk Assessment
+
+<!-- Describe the risk of this change and how it will be tested, deployed, and verified. -->
+
+- [ ] Large/complex change?
+- [ ] Big splash zone?
+- [ ] Low margin for error?
+- [ ] Low confidence?
+- [ ] No/flipping feature flag?
+
 ### Changes
 
 <!--
@@ -37,13 +47,11 @@ Please include any notes that might be helpful for a reviewer to check the depen
 ### Ticket
 
 <!-- Fill in the ticket information with the details of your feature -->
-[XX-1234](https://customink.atlassian.net/browse/XX-1234)
+[Monday issue](https://customink.monday.com/boards/12345/pulses/12345)
 
 ### Screenshots
 
-<!--
-Please include any screenshots that communicate the visual story of the change that is being made.
--->
+<!-- Communicate the visual story of the change that is being made. -->
 
 ### Notes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,11 +20,12 @@ change ingress
 -->
 
 ### Risk Assessment _[(learn more)](https://app.getguru.com/card/iMnRRRjT/PR-Risk-Assessment)_
+<!-- WIP: Some teams are experimenting with this section. Fee free to remove. -->
 <!-- Describe the risk of this change and how it will be tested, deployed, and verified. -->
 
 - [ ] Large/complex change?
 - [ ] Big splash zone?
-- [ ] Low margin for error?
+- [ ] High stakes if errors occur?
 - [ ] Low confidence?
 - [ ] No/flipping feature flag?
 


### PR DESCRIPTION
### Stakeholder Overview
We are experimenting with a new part of our PR and deployment process called Risk Assessment. This is a very quick checklist and description of the risk and deployment approach, done for each PR. We are going ahead and adding it to the template for teams that want to start using the process and providing feedback on it.

Read more here: https://app.getguru.com/card/iMnRRRjT/PR-Risk-Assessment

### Changes
- Add "Risk Assessment" section
- Tidy up a few of the comments
- Change "JIRA ticket" to "Monday issue"