### PR TITLE
Risk estimate language tweaks, negligible risk option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,15 +19,16 @@ Bad example:
 change ingress
 -->
 
-### Risk Assessment _[(learn more)](https://app.getguru.com/card/iMnRRRjT/PR-Risk-Assessment)_
+### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
 <!-- WIP: Some teams are experimenting with this section. Fee free to remove. -->
-<!-- Describe the risk of this change and how it will be tested, deployed, and verified. -->
+_[Replace this with a description of the risk, if any, and how the change will be deployed.]_
 
-- [ ] Large/complex change?
+- [ ] Big/complex change?
 - [ ] Big splash zone?
 - [ ] High stakes if errors occur?
 - [ ] Low confidence?
-- [ ] No/flipping feature flag?
+- [ ] Hidden by feature flag?
+- [ ] Negligible risk!
 
 ### Changes
 


### PR DESCRIPTION
### Stakeholder Overview
Incorporating some feedback from various corners about how to improve the Risk Estimate section, including:
- Opt for "estimate" over "assessment"
- Add a "negligible risk" option to be used if if no other boxes apply
- Clarify feature flag language

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/PR-Risk-Assessment)_
These are minor tweaks to an experimental part of the PR template. Not a deploy per se but it does affect PR authorship across the organization. Given the small changes and flux of this section, risk is low.

- [ ] Big/complex change?
- [x] Big splash zone?
- [ ] High stakes if errors occur?
- [ ] Low confidence?
- [ ] Hidden by feature flag?
- [ ] Negligible risk!