### PR TITLE
fix template typo for feature flag item

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@ _[Replace this with a description of the risk, if any, and how the change will b
 - [ ] Big splash zone?
 - [ ] High stakes if errors occur?
 - [ ] Low confidence?
-- [ ] Hidden by feature flag?
+- [ ] Not hidden by feature flag?
 - [ ] Negligible risk!
 
 ### Changes


### PR DESCRIPTION
### Stakeholder Overview
Fixing a typo from the risk estimate changes in #13.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
This fixes a typo in the risk estimate section (meta!)

- [ ] Big/complex change?
- [ ] Big splash zone?
- [ ] High stakes if errors occur?
- [ ] Low confidence?
- [ ] Hidden by feature flag?
- [x] Negligible risk!