### PR TITLE
Remove fake tasks

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,12 +8,13 @@ Provide a concise summary of the motivation and the driving force behind this ch
 <!-- WIP: Some teams are experimenting with this section. Fee free to remove. -->
 _[Replace this with a description of the risk, if any, and how the change will be deployed.]_
 
-- [ ] Big/complex change?
-- [ ] Big splash zone?
-- [ ] High stakes if errors occur?
-- [ ] Low confidence?
-- [ ] Not hidden by feature flag?
-- [ ] Negligible risk!
+<!-- add a ✅ or 🚫 as appropriate -->
+- Big/complex change?
+- Big splash zone?
+- High stakes if errors occur?
+- Low confidence?
+- Not hidden by feature flag?
+- Negligible risk!
 
 ### Changes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,13 +8,13 @@ Provide a concise summary of the motivation and the driving force behind this ch
 <!-- WIP: Some teams are experimenting with this section. Fee free to remove. -->
 _[Replace this with a description of the risk, if any, and how the change will be deployed.]_
 
-<!-- add a ✅ or 🚫 as appropriate -->
-- Big/complex change?
-- Big splash zone?
-- High stakes if errors occur?
-- Low confidence?
-- Not hidden by feature flag?
-- Negligible risk!
+<!-- remove any that do not apply -->
+- ✅ Big/complex change
+- ✅ Big splash zone
+- ✅ High stakes if errors occur
+- ✅ Low confidence
+- ✅ Not hidden by feature flag
+- ✅ Negligible risk!
 
 ### Changes
 


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

Unchecked risk categories are not unfinished "tasks", but github parses them as such.  This also conflicts with PRs that wish to use the task feature to keep track of features within a PR.  This would change the format to a list and encourage people to use appropriate emoji instead for readability.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
This is an example of what usage might look like, and also an accurate risk estimate of the PR. (risk is super low, but it does affect every repo.)

- ✅ Big splash zone
- ✅ Negligible risk
