### PR TITLE
Update template based on observed IRL usage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,8 @@ Provide a concise summary of the motivation and the driving force behind this ch
 -->
 
 ### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
-_[Replace this with a description of the risk, if any, and how the change will be deployed.]_
+
+<!-- Optionally add a description of the risk, and how the change will be deployed. -->
 
 <!-- remove any that do not apply -->
 - ⚠️ Big/complex change
@@ -30,10 +31,11 @@ Please include any notes that might be helpful for a reviewer to check the depen
   - data model update
 -->
 
-### Ticket
+### Project Link
 
 <!-- Fill in the ticket information with the details of your feature -->
-[Monday issue](https://customink.monday.com/boards/12345/pulses/12345)
+<!-- [Monday issue](https://customink.monday.com/boards/12345/pulses/12345) -->
+<!-- [Project pitch](https://docs.google.com/document/d/1X7qdItdxoxC6p0MertCjfyzlKw_T2M79yQknTlPQOF4) -->
 
 ### Screenshots
 


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_

I'm recommending the following changes based on months of observing how these PR templates are typically used:

1. Renames the ticket section to be more generic. Some teams prefer to link to the more informative project pitch than a (typically) vague Monday item.
2. Makes the Risk Estimate description optional. Most are just leaving the "replace this with..." text as is.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_

- ✅ Negligible risk!

### What GIF Best Describes This Pull Request?
<img src="https://media2.giphy.com/media/8vFwTyU8iwZilmMFIQ/giphy.gif"/>
<!--
![](https://i.giphy.com/media/WNuF3KK9NaQ8w/source.gif)
-->
